### PR TITLE
Comment out developer attribution in Footer component

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,8 +6,8 @@ const today = new Date();
   <div class="pb-2">
     &copy; {today.getFullYear()} Jaafar Harabi
   </div>
-  <div class="inline opacity-75">
+  <!-- <div class="inline opacity-75">
     Developed by <a href="https://www.linkedin.com/in/jaafar-harabi/" target="_blank" class="font-bold">Jaafar Harabi</a>
-  </div>
+  </div> -->
 </footer>
 <style></style>


### PR DESCRIPTION
Remove the developer attribution from the Footer component to streamline the footer's appearance.